### PR TITLE
添加http实用方法

### DIFF
--- a/events/http.go
+++ b/events/http.go
@@ -68,17 +68,17 @@ func (receiver HTTPTriggerEvent) ReadHeader(name string) (context string, err er
 	}
 	return context, nil
 }
-func (receiver HTTPTriggerResponse) SetStatusCode(StatusCode int) error {
+func (receiver *HTTPTriggerResponse) SetStatusCode(StatusCode int) error {
 	if StatusCode < 100 || StatusCode > 599 {
 		return errors.New("invalid status code")
 	}
 	receiver.StatusCode = StatusCode
 	return nil
 }
-func (receiver HTTPTriggerResponse) SetHeader(name string, value string) {
+func (receiver *HTTPTriggerResponse) SetHeader(name string, value string) {
 	receiver.Headers[name] = value
 }
-func (receiver HTTPTriggerResponse) WriteBody(context interface{}) error {
+func (receiver *HTTPTriggerResponse) WriteBody(context interface{}) error {
 	val := reflect.ValueOf(context)
 	switch val.Kind() {
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:

--- a/events/http.go
+++ b/events/http.go
@@ -75,8 +75,8 @@ func (receiver HTTPTriggerResponse) SetStatusCode(StatusCode int) error {
 	receiver.StatusCode = StatusCode
 	return nil
 }
-func (receiver HTTPTriggerResponse) SetHeader(Header string) {
-	receiver.Headers[Header] = Header
+func (receiver HTTPTriggerResponse) SetHeader(name string, value string) {
+	receiver.Headers[name] = value
 }
 func (receiver HTTPTriggerResponse) WriteBody(context interface{}) error {
 	val := reflect.ValueOf(context)

--- a/events/http.go
+++ b/events/http.go
@@ -1,5 +1,12 @@
 package events
 
+import (
+	"encoding/json"
+	"errors"
+	"reflect"
+	"strconv"
+)
+
 // HTTPTriggerEvent 事件输入
 type HTTPTriggerEvent struct {
 	Version         *string            `json:"version"`         // HTTP 触发器请求事件版本
@@ -37,4 +44,86 @@ type HTTPTriggerResponse struct {
 	Headers         map[string]string `json:"headers"`
 	IsBase64Encoded bool              `json:"isBase64Encoded"`
 	Body            string            `json:"body"`
+}
+
+func (receiver HTTPTriggerEvent) ReadParameter(name string) (context string, err error) {
+	if receiver.QueryParameters == nil {
+		return "", errors.New("query parameters is nil")
+	}
+	var exists bool
+	context, exists = (*receiver.QueryParameters)[name]
+	if !exists {
+		return "", errors.New("target parameter not found")
+	}
+	return context, nil
+}
+func (receiver HTTPTriggerEvent) ReadHeader(name string) (context string, err error) {
+	if receiver.Headers == nil {
+		return "", errors.New("headers is nil")
+	}
+	var exists bool
+	context, exists = (*receiver.Headers)[name]
+	if !exists {
+		return "", errors.New("target header not found")
+	}
+	return context, nil
+}
+func (receiver HTTPTriggerResponse) SetStatusCode(StatusCode int) error {
+	if StatusCode < 100 || StatusCode > 599 {
+		return errors.New("invalid status code")
+	}
+	receiver.StatusCode = StatusCode
+	return nil
+}
+func (receiver HTTPTriggerResponse) SetHeader(Header string) {
+	receiver.Headers[Header] = Header
+}
+func (receiver HTTPTriggerResponse) WriteBody(context interface{}) error {
+	val := reflect.ValueOf(context)
+	switch val.Kind() {
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		receiver.Body = strconv.FormatInt(val.Int(), 10)
+	case reflect.String:
+		receiver.Body = context.(string)
+	case reflect.Struct:
+		jsonByte, _ := json.Marshal(context)
+		receiver.Body = string(jsonByte)
+	case reflect.Invalid:
+		return errors.New("invalid type")
+	case reflect.Bool:
+		receiver.Body = strconv.FormatBool(context.(bool))
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		receiver.Body = strconv.FormatUint(val.Uint(), 10)
+	case reflect.Uintptr:
+	case reflect.Float32, reflect.Float64:
+		receiver.Body = strconv.FormatFloat(val.Float(), 'f', -1, 64)
+	case reflect.Complex64, reflect.Complex128:
+		return errors.New("imaginary numbers are not supported, please assemble real and imaginary parts into one type, e.g., map,array")
+	case reflect.Array:
+		jsonByte, err := json.Marshal(context)
+		if err != nil {
+			return err
+		}
+		receiver.Body = string(jsonByte)
+	case reflect.Chan:
+		return errors.New("unsupported type")
+	case reflect.Func:
+		return errors.New("unsupported type")
+	case reflect.Interface:
+		return errors.New("interface{} are not guaranteed to be encoded")
+	case reflect.Map:
+		jsonByte, _ := json.Marshal(context)
+		receiver.Body = string(jsonByte)
+	case reflect.Slice:
+		jsonByte, err := json.Marshal(context)
+		if err != nil {
+			return err
+		}
+		receiver.Body = string(jsonByte)
+	case reflect.UnsafePointer:
+		return errors.New("unsafe pointer")
+	default:
+		return errors.New("unsupported type")
+	}
+	return nil
 }


### PR DESCRIPTION
为http添加了一些快捷操作，方便编写者操作输入和输出。
未经过测试,并且没有编写相应的文档，项目人员请暂时不要处理，测试完毕后会发出结果以便参考。